### PR TITLE
Tomcat 8, jQuery upgrade and add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Leeor Engel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ Tested on latest Chrome and Firefox for tomcat versions 6, 7 & 8.
 http://benalman.com/code/test/jquery-run-code-bookmarklet/
 
 for bookmarklet skeleton with jquery.
+
+# License
+
+Code licensed under [MIT license](https://github.com/leeorengel/tomcatStatusPretty/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Feel free to play with the colors or the color-coding rules to suit your needs.
 
 Just copy the contents of tomcatStatusPretty.js into the address field of a new bookmark in your browser. Then load the tomcat manager status page and click on the bookmark - voila! Pretty color coded, and cleaned up request entries.
 
-Tested on latest Chrome and Firefox for tomcat versions 6 & 7.
+Tested on latest Chrome and Firefox for tomcat versions 6, 7 & 8.
 
 # Credits
 

--- a/tomcatStatusPretty.js
+++ b/tomcatStatusPretty.js
@@ -1,4 +1,4 @@
-javascript:(function(e,a,g,h,f,c,b,d){if(!(f=e.jQuery)||g>f.fn.jquery||h(f)){c=a.createElement("script");c.type="text/javascript";c.src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js";c.onload=c.onreadystatechange=function(){if(!b&&(!(d=this.readyState)||d=="loaded"||d=="complete")){h((f=e.jQuery).noConflict(1),b=1);f(c).remove()}};a.documentElement.childNodes[0].appendChild(c)}})(window,document,"1.3.2",function($,L){
+javascript:(function(e,a,g,h,f,c,b,d){if(!(f=e.jQuery)||g>f.fn.jquery||h(f)){c=a.createElement("script");c.type="text/javascript";c.src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js";c.onload=c.onreadystatechange=function(){if(!b&&(!(d=this.readyState)||d=="loaded"||d=="complete")){h((f=e.jQuery).noConflict(1),b=1);f(c).remove()}};a.documentElement.childNodes[0].appendChild(c)}})(window,document,"1.3.2",function($,L){
 	
 $("td > strong:contains('K')").closest('tr').remove();
 $("td > strong:contains('R')").closest('tr').remove();

--- a/tomcatStatusPretty_commented.js
+++ b/tomcatStatusPretty_commented.js
@@ -1,4 +1,4 @@
-javascript:(function(e,a,g,h,f,c,b,d){if(!(f=e.jQuery)||g>f.fn.jquery||h(f)){c=a.createElement("script");c.type="text/javascript";c.src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js";c.onload=c.onreadystatechange=function(){if(!b&&(!(d=this.readyState)||d=="loaded"||d=="complete")){h((f=e.jQuery).noConflict(1),b=1);f(c).remove()}};a.documentElement.childNodes[0].appendChild(c)}})(window,document,"1.3.2",function($,L){
+javascript:(function(e,a,g,h,f,c,b,d){if(!(f=e.jQuery)||g>f.fn.jquery||h(f)){c=a.createElement("script");c.type="text/javascript";c.src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js";c.onload=c.onreadystatechange=function(){if(!b&&(!(d=this.readyState)||d=="loaded"||d=="complete")){h((f=e.jQuery).noConflict(1),b=1);f(c).remove()}};a.documentElement.childNodes[0].appendChild(c)}})(window,document,"1.3.2",function($,L){
 
 // Remove all non-service request rows
 $("td > strong:contains('K')").closest('tr').remove();


### PR DESCRIPTION
- Verified bookmarklet works with tomcat 8 so updated README
- Upgraded jQuery to latest in both main and commented js files
- Added MIT license and note about it in README.md.

Note: the license link in README.md will be broken until you merge this PR.
